### PR TITLE
Refactoring UnitCreate

### DIFF
--- a/UnitCreate.html
+++ b/UnitCreate.html
@@ -21,43 +21,144 @@
     <script defer src="../js/jquery.xdomainajax.js"></script>
 </head>
 <body class="body container" style="color:black;">
-    <button class="btn btn-default" onclick="PUSH()">整形</button>
+    <button id="push" class="btn btn-default">整形</button>
     <div id="main">
         <textarea style="width:100%;height:300px;" id="text" placeholder="">[Unitname],[Idol1] × [Idol2].....</textarea>
         <textarea style="width:100%;height:300px;" id="rdf"></textarea>
     </div>
     <script>
-        function PUSH() {
-            const Query=["PREFIX schema: <http://schema.org/> SELECT ?s WHERE { ?s schema:name ?o; filter(regex(str(?o),\"","\")).}"];
-            var units = $("#text")[0].value.split(/\r\n|\r|\n/);
-            $("#rdf")[0].value = "";
-            units.forEach(function (i) {
-                var str=i.split(',');
-                var UnitName=str[0];
-                var UnitMembers = str[1].split(/ × | \/ /g);
-                $("#rdf")[0].value+="<rdf:Description rdf:about=\""+encodeURIComponent(UnitName)+"\">\n";
-                $("#rdf")[0].value+="    <schema:name rdf:datatype=\"https://www.w3.org/TR/xmlschema11-2/#string\">"+UnitName+"</schema:name>\n";
+        /**
+         * ユニット情報
+         *
+         * @typedef {Object} UnitInfo
+         * @property {string} name - ユニット名
+         * @property {string[]} members - ユニットメンバーの配列
+         * @example { name: "マイティーセーラーズ", members: ["高坂海美", "伊吹翼", "七尾百合子"] }
+         */
 
-                UnitMembers.forEach(function (j) {
-                    var url='https://sparql.crssnky.xyz/spql/imas/query?query='+encodeURIComponent(Query[0]+j+Query[1]);
-                    $.ajaxSetup({ async: false });
-                    $.getJSON(url,function (data,status) {
-                        var jsons=data["results"]["bindings"];
-                        if (jsons.length==0) {
-                            if (j!="ジュリア")
-                                alert(j+':データベース内に見つかりませんでした。');
-                            else
-                                $("#rdf")[0].value+="    <schema:member rdf:resource=\"https://sparql.crssnky.xyz/imasrdf/Julia\"/>\n";
-                        } else {
-                            $("#rdf")[0].value+="    <schema:member rdf:resource=\""+jsons[0].s.value+"\"/>\n";
-                        }
-                    });
-                });
+        /**
+         * アイドル情報
+         *
+         * @typedef {Map<string, string>} IdolInfo
+         * @example Map{ "高坂海美" => "https://〜", "伊吹翼" => "https://〜", "七尾百合子" => "https://〜" }
+         */
 
-                $("#rdf")[0].value+="    <rdf:type rdf:resource=\"https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit\"/>\n";
-                $("#rdf")[0].value+="  </rdf:Description>\n";
-            });
+        /**
+         * im@sparql に問い合わせる URL を組み立てる
+         *
+         * @param {Set<string>} idols - アイドル名の Set
+         * @return {URL} - im@sparql に問い合わせるURL
+         */
+        function buildQuery(idols) {
+            const values = [...idols].map(idol => `"${idol}"`).join(' ');
+            const query = `
+                PREFIX imas: <https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#>
+                PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                SELECT ?uri ?name WHERE { ?uri a imas:Idol ; rdfs:label ?name . }
+                VALUES ?name { ${values} }
+            `.trim();
+
+            const url = new URL('https://sparql.crssnky.xyz/spql/imas/query');
+            url.searchParams.set('query', query);
+            return url;
         }
+
+        /**
+         * im@sparql に問い合わせて整形して返す
+         *
+         * @param {URL} query - im@sparql に問い合わせるURL
+         * @return {IdolInfo} - アイドル情報
+         */
+        function fetchResource(query) {
+            return fetch(query).then(res => res.json()).then(json =>
+                json.results.bindings.reduce((map, { uri, name }) =>
+                    map.set(name.value, uri.value),
+                    new Map()
+                )
+            );
+        }
+
+        /**
+         * 入力用テキストエリアをパースする
+         *
+         * @param {string} text - 入力用テキストエリアの文字列
+         * @return {UnitInfo[]} - ユニット情報の配列
+         */
+        function parse(text) {
+            const units = [];
+            const lines = text.split(/\r?\n/)
+            for (const line of lines) {
+                const [name, members] = line.split(',');
+                units.push({ name, members: members.split(/ [×\/] /g) });
+            }
+            return units;
+        }
+
+        /**
+         * RDF を生成する
+         *
+         * @param {UnitInfo} unitInfo - ユニット情報
+         * @param {IdolInfo} idolInfo - アイドル情報
+         * @return {string} - RDF
+         */
+        function generate(unitInfo, idolInfo) {
+            const members = [];
+            for (const member of unitInfo.members) {
+                if (!idolInfo.has(member)) {
+                    throw new Error(`「${member}」はデータベース内に見つかりませんでした。`);
+                }
+                members.push(`    <schema:member rdf:resource="${idolInfo.get(member)}"/>`);
+            }
+            const lines = [
+                `  <rdf:Description rdf:about="detail/${encodeURIComponent(unitInfo.name)}">`,
+                `    <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">${unitInfo.name}</schema:name>`,
+                ...members,
+                `    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>`,
+                `  </rdf:Description>`,
+            ];
+            return lines.join('\n');
+        }
+
+        /**
+         * 入力されたすべてのユニットからアイドル名を収集する
+         *
+         * @param {UnitInfo[]} ユニット情報の配列
+         * @return {Set<string>} アイドル名の Set
+         */
+        function collectAllIdols(units) {
+            const idols = new Set();
+            for (const { members } of units) {
+                members.forEach(member => idols.add(member));
+            }
+            return idols;
+        }
+
+        document.getElementById('push').addEventListener('click', async () => {
+            try {
+                const input = document.getElementById('text');
+                const output = document.getElementById('rdf');
+
+                // 入力用テキストエリアをパース
+                const units = parse(input.value);
+
+                // アイドルの URI を取得する
+                const allIdols = collectAllIdols(units);
+                const query = buildQuery(allIdols);
+                const idolInfo = await fetchResource(query);
+
+                // RDF を生成する
+                const rdfs = [];
+                for (const unitInfo of units) {
+                    const rdf = generate(unitInfo, idolInfo);
+                    rdfs.push(rdf);
+                }
+
+                // RDF を出力する
+                output.value = rdfs.join('\n');
+            } catch (e) {
+                alert(e);
+            }
+        });
     </script>
 </body>
 </html>

--- a/UnitCreate.html
+++ b/UnitCreate.html
@@ -56,7 +56,7 @@
                 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
                 SELECT ?uri ?name WHERE { ?uri a imas:Idol ; rdfs:label ?name . }
                 VALUES ?name { ${values} }
-            `.trim();
+            `.replace(/    /g, '');
 
             const url = new URL('https://sparql.crssnky.xyz/spql/imas/query');
             url.searchParams.set('query', query);
@@ -102,15 +102,17 @@
          * @return {string} - RDF
          */
         function generate(unitInfo, idolInfo) {
+            const BASE = 'https://sparql.crssnky.xyz/imasrdf/RDFs/detail/';
             const members = [];
             for (const member of unitInfo.members) {
                 if (!idolInfo.has(member)) {
                     throw new Error(`「${member}」はデータベース内に見つかりませんでした。`);
                 }
-                members.push(`    <schema:member rdf:resource="${idolInfo.get(member)}"/>`);
+                const uri = idolInfo.get(member).replace(BASE, '');
+                members.push(`    <schema:member rdf:resource="${uri}"/>`);
             }
             const lines = [
-                `  <rdf:Description rdf:about="detail/${encodeURIComponent(unitInfo.name)}">`,
+                `  <rdf:Description rdf:about="${encodeURIComponent(unitInfo.name)}">`,
                 `    <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">${unitInfo.name}</schema:name>`,
                 ...members,
                 `    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>`,
@@ -125,7 +127,7 @@
          * @param {UnitInfo[]} ユニット情報の配列
          * @return {Set<string>} アイドル名の Set
          */
-        function collectAllIdols(units) {
+        function collectIdols(units) {
             const idols = new Set();
             for (const { members } of units) {
                 members.forEach(member => idols.add(member));
@@ -142,8 +144,8 @@
                 const units = parse(input.value);
 
                 // アイドルの URI を取得する
-                const allIdols = collectAllIdols(units);
-                const query = buildQuery(allIdols);
+                const idols = collectIdols(units);
+                const query = buildQuery(idols);
                 const idolInfo = await fetchResource(query);
 
                 // RDF を生成する


### PR DESCRIPTION
# 変更点

- スクリプト部分を全体的に書き直しました。
- rdfs:label や datatype の変更に追従しました。
- [高速化] アイドルごとに叩いていたクエリがひとつで済むようになりました。
- [破壊的変更] クエリを変更しました。
  - 部分一致から完全一致に変更しました。
  - 主語の rdf:type を imas:Idol に絞るようにしました。

クエリを変更した理由ですが、現状たとえば「ロコ」と入力すると「[Atractive_Roco_World](https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Atractive_Roco_World)」が取れてきます（正しくは「伴田路子」と入力する必要があります）。気づかずに im@sparql に取り込まれてしまう可能性が否定できないため、検索の対象を絞り込むことで安全側に倒すほうが良いと考えます。